### PR TITLE
chore: release 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push-plugin",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Config plugin to auto configure react-native-code-push on prebuild",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Cuts 1.0.8 so the expo monorepo path fix from #12 actually reaches people.

npm is still on 1.0.7, so #9 is fixed on master but not in anyone's node_modules yet.

## What's in it
- #12: codepush.gradle and the codepush android project are resolved through node instead of hardcoded `../../node_modules` paths, so hoisted/pnpm workspace setups stop failing with "Could not read script"

Version bump only, no code changes on this branch.