### PR TITLE
docs: note App Center retirement and require CodePushServerURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Config plugin to auto-configure [`react-native-code-push`][lib] when the native code is generated (`npx expo prebuild`).
 
+> ### App Center is retired
+>
+> Microsoft retired App Center and its hosted CodePush service on March 31, 2025, and archived both [`react-native-code-push`][lib-repo] and [`code-push-server`][server-repo] on May 20, 2025. `appcenter codepush release-react` no longer has a service to talk to.
+>
+> This plugin only writes native config at prebuild. It has to point at a CodePush server you host yourself, from the archived [`code-push-server`][server-repo] source. `CodePushServerURL` is required now: leave it out and the SDK falls back to `https://codepush.appcenter.ms/`. If running your own server isn't worth it, [`expo-updates`][expo-updates] replaces both CodePush and this plugin.
 
 ### Add the package to your npm dependencies
 
@@ -31,11 +36,11 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
         "react-native-code-push-plugin",
         {
           "android": {
-            "CodePushServerURL": "YOUR_CODE_PUSH_SERVER_URL", // Optional. Pass this value to configure a self-hosted codepush server.
+            "CodePushServerURL": "YOUR_CODE_PUSH_SERVER_URL",
             "CodePushDeploymentKey": "YOUR_ANDROID_CODE_PUSH_KEY"
           },
           "ios": {
-            "CodePushServerURL": "YOUR_CODE_PUSH_SERVER_URL", // Optional. Pass this value to configure a self-hosted codepush server.
+            "CodePushServerURL": "YOUR_CODE_PUSH_SERVER_URL",
             "CodePushDeploymentKey": "YOUR_IOS_CODE_PUSH_KEY"
           }
         }
@@ -48,3 +53,6 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
 [lib]: https://www.npmjs.com/package/react-native-code-push
+[lib-repo]: https://github.com/microsoft/react-native-code-push
+[server-repo]: https://github.com/microsoft/code-push-server
+[expo-updates]: https://docs.expo.dev/versions/latest/sdk/updates/


### PR DESCRIPTION
App Center and its hosted CodePush service were retired on 2025-03-31. `microsoft/react-native-code-push` and `microsoft/code-push-server` were both archived on 2025-05-20.

This matters for the plugin's defaults. When `CodePushServerURL` is unset, `withIosInfoPlistDependency` and `withAndroidStringsDependency` skip writing the key entirely, so the SDK stays on its built-in default:

- `android/.../CodePush.java:43` -> `private static String mServerUrl = "https://codepush.appcenter.ms/";`
- `ios/CodePush/CodePushConfig.m:49` -> `serverURL = @"https://codepush.appcenter.ms/";`

That host no longer answers, so the prop isn't optional anymore. Removes the stale `// Optional.` comments and adds a short note at the top pointing at self-hosting from the archived `code-push-server` source, or `expo-updates` for anyone who doesn't want to run one.

Docs only, no code change, so no release needed.

Context: #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uj6xe9Bt2zFYmqU6UTTkQ