### PR TITLE
fix(deps): declare @babel/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expo": ">=49.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "expo": ">=49.0.0",
     "expo-module-scripts": "^3.0.3",
     "jest": "^29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,7 +39,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
   integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.20.0", "@babel/core@^7.23.9", "@babel/core@^7.25.2":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.20.0", "@babel/core@^7.23.9", "@babel/core@^7.25.2", "@babel/core@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==


### PR DESCRIPTION
Adds `@babel/core` to `devDependencies`. `yarn install` drops from 139 warnings to 36.

The build toolchain needs it: `@babel/cli`, `@babel/preset-env`, `@babel/preset-typescript`, `babel-preset-expo` and `babel-jest` all peer-require it, and it was never declared here. 103 of the 139 install warnings were that one missing entry:

```
warning "expo-module-scripts > @babel/cli@7.29.7" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo-module-scripts > @babel/preset-env@7.29.7" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo-module-scripts > jest-expo > babel-jest@29.7.0" has unmet peer dependency "@babel/core@^7.8.0".
```

Builds work today because yarn hoists `@babel/core` to the root anyway. Nothing pins that behaviour, and a package manager with stricter resolution drops it.

## Verification

No CI here, so this is local from a clean `node_modules`:

- `yarn install --ignore-scripts`: 139 warnings before, 36 after, none mentioning `@babel/core`
- `@babel/core` still resolves to 7.29.7, so `yarn.lock` only gains the new range on the existing entry
- `yarn build` succeeds
- `yarn test` passes, 1 suite, 5 tests

## Lint

`yarn lint` exits 2:

```
ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
```

`.eslintrc.js` is eslintrc format and `expo-module-scripts` shells out to `npx eslint`, which grabs `eslint@latest` off the registry because eslint isn't a dependency of this repo or of `expo-module-scripts`. Today that's 10.8.0, which is flat-config only. Pinning back to `eslint@8.57.1` doesn't help either, the hoisted plugins then fail to `require('eslint')`.

Fixing it means either a flat config plus a real eslint dependency, or moving off `expo-module-scripts@3.5.4`, which is SDK 51 era while this repo resolves `expo@57.0.8`. Worth its own PR.
