### PR TITLE
chore: scope resolutions to clear 6 dev-only Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
     "expo-module-scripts": "^3.0.3",
     "jest": "^29"
   },
+  "resolutions": {
+    "**/@expo/plist/@xmldom/xmldom": "0.8.13",
+    "**/@typescript-eslint/typescript-estree/minimatch": "9.0.7",
+    "**/xcode/uuid": "11.1.1"
+  },
   "upstreamPackage": "react-native-code-push"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,7 +2364,7 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz#094041e1a4cb1987f038335421281ac8be390bcc"
   integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
 
-"@xmldom/xmldom@^0.8.8":
+"@xmldom/xmldom@0.8.13", "@xmldom/xmldom@^0.8.8", "@xmldom/xmldom@~0.7.7":
   version "0.8.13"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
   integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
@@ -2373,11 +2373,6 @@
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.10.tgz#a0ad5a26fe8aa996310870726e1704977f769dee"
   integrity sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==
-
-"@xmldom/xmldom@~0.7.7":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.13.tgz#ff34942667a4e19a9f4a0996a76814daac364cf3"
-  integrity sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==
 
 abab@^2.0.6:
   version "2.0.6"
@@ -2912,14 +2907,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^5.0.5:
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
   integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
@@ -5864,12 +5852,12 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@9.0.3, minimatch@9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.7.tgz#d76c4d0b3b527877016d6cc1b9922fc8e0ffe7b0"
+  integrity sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^5.0.2"
 
 minimatch@^10.2.2:
   version "10.2.5"
@@ -7458,10 +7446,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@11.1.1, uuid@^7.0.3:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Clears the six remaining Dependabot alerts. They're all against yarn.lock and all dev-only. This package ships peerDependencies only (`expo: >=49.0.0`), so none of this reaches anyone who installs it.

Each one is pinned transitively with no upgrade path through its direct parent, so they're scoped resolutions:

| package | from | to | pinned by |
|---|---|---|---|
| `@xmldom/xmldom` | 0.7.13 | 0.8.13 | `jest-expo` 51 -> `@expo/config-plugins` 8.0.11 -> `@expo/plist` 0.1.3 |
| `minimatch` | 9.0.3 | 9.0.7 | `@typescript-eslint/typescript-estree` 6.21.0 (exact pin) |
| `uuid` | 7.0.3 | 11.1.1 | `xcode` 3.0.1 |

xmldom is four of the six alerts. Only the copy nested under `jest-expo` was still on 0.7.13; the one the real prebuild path uses (`@expo/config-plugins` 57, the unified-versioned line, -> `@expo/plist` 0.8.1) was already patched. I scoped the resolution to `@expo/plist` so the unrelated `plist` package keeps its 0.9.x.

uuid is the biggest jump. `xcode` 3.0.1 is the latest published version and still asks for `uuid ^7.0.3`, so there's no parent bump available. `xcode` only calls `require('uuid').v4()`, and uuid 11 still exports `v4` from its CJS build.

minimatch reaches us through `expo-module-scripts` -> `eslint-config-universe` 12 -> `@typescript-eslint` 6, so bumping the parent means bumping `expo-module-scripts`.

That would be the root fix for the jest-expo chain too: `expo-module-scripts` 3.5.4 -> 56.0.3. I tried it, it breaks `yarn build`. 56 stopped bundling typescript and `@types/node`, and its base tsconfig no longer includes node types, so it needs two new devDependencies plus a tsconfig change before `tsc` will pass. That changes how the published `build/` gets type-checked. Not worth it for six dev-only alerts, so I left it for its own PR.

## Verification

No CI in this repo, so all local:

- `yarn build` clean, `yarn test` 5/5
- `xcode` on uuid 11: parsed a pbxproj, ran `addPbxGroup` / `addSourceFile` / `addFramework` (all of which call `generateUuid`), wrote it back out, re-parsed it, no UUID collisions
- full `compileModsAsync` applying this plugin to a scaffolded RN project. Info.plist, strings.xml, settings.gradle, app/build.gradle and MainApplication.kt all came out patched correctly, with Info.plist round-tripping through `@expo/plist` on xmldom 0.8.13

`yarn lint` still fails exactly like it did before this branch: ESLint resolves to v10 and wants flat config while the repo has `.eslintrc.js`.

`package.json` + `yarn.lock` only, so no release needed.

https://claude.ai/code/session_015uj6xe9Bt2zFYmqU6UTTkQ
