### PR TITLE
chore(release): v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.0.10](https://github.com/GSTJ/react-native-code-push-plugin/compare/v1.0.9...v1.0.10) (2026-07-27)
+
+### Bug Fixes
+
+* **release:** keep the changelog headings in the tag message ([0c6c8c1](https://github.com/GSTJ/react-native-code-push-plugin/commit/0c6c8c1b740858654b4ada1a062874be9302db22))
+
+### Continuous Integration
+
+* land release bumps through a PR instead of pushing to master ([#19](https://github.com/GSTJ/react-native-code-push-plugin/issues/19)) ([a7016d2](https://github.com/GSTJ/react-native-code-push-plugin/commit/a7016d264e5a4b14b1bdb8b3e9fe788e1357b60f))
+
 ## [1.0.9](https://github.com/GSTJ/react-native-code-push-plugin/compare/v1.0.8...v1.0.9) (2026-07-26)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push-plugin",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Config plugin to auto configure react-native-code-push on prebuild",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Version bump and changelog for [v1.0.10](https://github.com/GSTJ/react-native-code-push-plugin/releases/tag/v1.0.10). npm and the tag are already out; this lands the commit the tag points at.

The release workflow pushed this branch and then failed to open the PR: "GitHub Actions is not permitted to create or approve pull requests". That repo setting is off by default and is now on, so the next release opens its own PR. Opened by hand to unstrand master.

Merging as a merge commit. A squash would rewrite the commit and leave the tag outside master's history, which breaks the changelog range for the next release.
