### PR TITLE
ci: call the shared workflow by tag instead of @main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
   checks:
     # Install, lint, format and typecheck are the shared workflow's; node comes
     # from .nvmrc and pnpm from the `packageManager` field.
-    uses: GSTJ/magic/.github/workflows/ci.yml@main
+    #
+    # `@v1` is the moving major tag, so a fix in the shared workflow lands here
+    # on the next run. Never `@main`: an unreviewed merge there would rerun
+    # every consumer's CI.
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
     with:
       build-command: pnpm run build
       test-command: pnpm run test


### PR DESCRIPTION
`.github/workflows/ci.yml` called `GSTJ/magic/.github/workflows/ci.yml@main`, so an unreviewed merge in the tooling repo reran this repo's CI. Switched to `@v1`, the moving major tag — fixes still arrive on the next run, just after a release rather than after a merge.

`ci.yml` and the `setup` composite are byte-identical between `v1` (v1.4.0) and `main` today, so this changes nothing about what runs. The four inputs this repo passes — `build-command`, `test-command`, `extra-command`, `turbo-cache` — all exist in v1's `workflow_call` signature with matching types (`turbo-cache` is a boolean there, which is what's passed).

Nothing else to do here:

- the `magic-*` devDependencies are already on the current latest (`magic-oxlint-config`/`magic-oxfmt-config`/`magic-tsconfig` 1.2.0, `magic-codemods` 1.1.0);
- `magic-oxlint-plugin` stays out — this repo enables none of its rules;
- `pnpm install --frozen-lockfile` passes against the committed `minimumReleaseAgeExclude` list, so no new quarantine entries were needed.

Verified locally: install (frozen), `lint` 0 diagnostics, `format --check` clean, `typecheck`, 5 jest tests, `build`, `npm pack --dry-run`.

Claude-Session: https://claude.ai/code/session_01Fe92vvdc4R3F4BDBFoLcw1