### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report it privately through GitHub's advisory form:
+https://github.com/GSTJ/react-native-code-push-plugin/security/advisories/new
+
+Don't open a public issue for a security problem.
+
+## Supported Versions
+
+Fixes ship in a new release off the latest published version. Stay on it; there are no backport branches.


### PR DESCRIPTION
I added a security policy here, and the same file to the other four publishing repos: safe-jsx, magic, react-native-magic-modal and react-native-magic-toast. Only the advisory link differs between them.

It points at GitHub's private advisory form:
https://github.com/GSTJ/react-native-code-push-plugin/security/advisories/new

I turned private vulnerability reporting on for all five repos.

I left the version support table out. safe-jsx had one written in 2023 that still claimed `1.1.x` was the supported line while the package sat at 1.3.4, and none of these packages keep backport branches. A table here would rot the same way. There's no response-time promise in it either, since that's not something anyone can hold to on a personal OSS project.

This one is a repo file only. I didn't touch any `files` array, and `npm pack` produces what it did before.
