### PR TITLE
build(deps): patch brace-expansion vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@expo/plist>@xmldom/xmldom': 0.8.13
   '@typescript-eslint/typescript-estree>minimatch': 9.0.7
+  brace-expansion@<1.1.17: ^1.1.17
   xcode>uuid: 11.1.1
 
 importers:
@@ -2208,8 +2209,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -8265,7 +8266,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10735,7 +10736,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,13 @@ minimumReleaseAgeExclude:
   - magic-oxfmt-config@1.2.0
   - magic-oxlint-config@1.2.0
   - magic-tsconfig@1.2.0
+  # Let the security fix through the global release-age gate.
+  - brace-expansion@1.1.17
 # pnpm 11 no longer reads the `pnpm` key from package.json, and `overrides` has
-# no other home, so this file exists for the three pins that used to live in
-# yarn's `resolutions`. Yarn's `**/a/b` globs become pnpm's `a>b` selectors.
+# no other home, so this file carries the old Yarn pins and scoped security
+# fixes. Yarn's `**/a/b` globs become pnpm's `a>b` selectors.
 overrides:
   "@expo/plist>@xmldom/xmldom": 0.8.13
   "@typescript-eslint/typescript-estree>minimatch": 9.0.7
+  brace-expansion@<1.1.17: ^1.1.17
   xcode>uuid: 11.1.1


### PR DESCRIPTION
## Summary

We replaced the vulnerable `brace-expansion` version in the development toolchain with the patched 1.1.18 release.

## Details

- Pins vulnerable `brace-expansion` releases below 1.1.17 to a patched version.
- Exempts the minimum fixed version from the repository-wide package age policy so pnpm can install the security update immediately.
- `react-native-code-push-plugin` stays at 1.0.14 because its published tarball doesn't include this development dependency.

## Testing steps

Run:

```sh
pnpm install --frozen-lockfile
pnpm audit --audit-level=low
pnpm run test --runInBand
npm pack --dry-run
```

Confirm the audit reports no known vulnerabilities, the tests pass, and the package tarball builds.
