### PR TITLE
build(deps): patch brace-expansion DoS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,8 @@ settings:
 overrides:
   '@expo/plist>@xmldom/xmldom': 0.8.13
   '@typescript-eslint/typescript-estree>minimatch': 9.0.7
-  brace-expansion@<1.1.17: ^1.1.17
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
   xcode>uuid: 11.1.1
 
 importers:
@@ -2212,8 +2213,8 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -8271,7 +8272,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10732,7 +10733,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -10740,7 +10741,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,12 +5,13 @@ minimumReleaseAgeExclude:
   - magic-oxlint-config@1.2.0
   - magic-tsconfig@1.2.0
   # Let the security fix through the global release-age gate.
-  - brace-expansion@1.1.17
+  - brace-expansion@1.1.18
 # pnpm 11 no longer reads the `pnpm` key from package.json, and `overrides` has
 # no other home, so this file carries the old Yarn pins and scoped security
 # fixes. Yarn's `**/a/b` globs become pnpm's `a>b` selectors.
 overrides:
   "@expo/plist>@xmldom/xmldom": 0.8.13
   "@typescript-eslint/typescript-estree>minimatch": 9.0.7
-  brace-expansion@<1.1.17: ^1.1.17
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
   xcode>uuid: 11.1.1


### PR DESCRIPTION
## Summary

We pinned both vulnerable `brace-expansion` branches to their patched releases, clearing GHSA-rgw5-rvv9-x895 from the development dependency graph.

## Details

- `1.x` now resolves to `1.1.18`.
- `5.x` now resolves to `5.0.9`.
- The dependency is only used by repository tooling and stays out of the published npm package.

## Testing steps

```sh
pnpm install --frozen-lockfile
pnpm audit
pnpm test --runInBand
npm pack --dry-run
```

Each command should exit successfully. The audit should report no known vulnerabilities.
