### PR TITLE
chore(deps): allow immediate magic tooling updates

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ minimumReleaseAgeExclude:
   - baseline-browser-mapping@2.11.3
   - brace-expansion@5.0.9
   - electron-to-chromium@1.5.396
+  - eslint-plugin-safe-jsx@1.3.0
   - expo-asset@57.0.7
   - expo-constants@57.0.7
   - expo-modules-autolinking@57.0.9
@@ -32,12 +33,8 @@ minimumReleaseAgeExclude:
   - release-it@21.0.0
   - sax@1.6.1
   - undici@7.29.0
-  # Allow the first-party tooling versions this repo was built against.
-  - eslint-plugin-safe-jsx@1.3.0
-  - magic-codemods@1.1.0
-  - magic-oxfmt-config@1.2.0
-  - magic-oxlint-config@1.2.0
-  - magic-tsconfig@1.2.0
+  # magic-* is first-party tooling and can update immediately.
+  - "magic-*"
   # Let the security fix through the global release-age gate.
   - brace-expansion@1.1.18
 # pnpm 11 no longer reads the `pnpm` key from package.json, and `overrides` has


### PR DESCRIPTION
## Summary

The pnpm policy now lets first-party `magic-*` packages update immediately while keeping the 14-day wait for every other dependency.

## Details

- Replaces four exact magic package exclusions with one `magic-*` rule, so later first-party releases do not need another config edit.
- Keeps `minimumReleaseAge` at 20,160 minutes for third-party releases.
- Keeps the dated lockfile grandfather and brace-expansion security exceptions exact to version.
- Leaves every dependency resolution unchanged.

## Testing steps

1. Check out this branch.
2. Run:

```sh
pnpm install --frozen-lockfile --ignore-scripts
pnpm audit
npm audit signatures
pnpm run lint
pnpm run format
pnpm run typecheck
pnpm run test
pnpm run build
npm pack --dry-run
pnpm run changelog:check
```

3. Confirm the install accepts the lockfile under the supply-chain policy, the audits pass, and every remaining command exits successfully.

![Local checks](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/6bf20de9d4141fe69c447b8eb901264f883f0be8/react-native-code-push-plugin/magic-release-age-exception-proof.png)
