### PR TITLE
fix!: require a working CodePush server URL

### DIFF
--- a/src/android/__tests__/config.test.ts
+++ b/src/android/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import type { ExpoConfig } from "expo/config";
+
+import { withAndroidStringsDependency } from "../strings-dependency";
+
+const config = { name: "test", slug: "test" } as ExpoConfig;
+
+describe("Android config", () => {
+  it.each([undefined, ""])(
+    "rejects a missing CodePush server URL",
+    (CodePushServerURL) => {
+      expect(() =>
+        withAndroidStringsDependency(config, {
+          android: {
+            CodePushDeploymentKey: "android-key",
+            CodePushServerURL: CodePushServerURL as string,
+          },
+          ios: {
+            CodePushDeploymentKey: "ios-key",
+            CodePushServerURL: "https://updates.example.com",
+          },
+        }),
+      ).toThrow(/App Center is retired/);
+    },
+  );
+
+  it("rejects a missing deployment key", () => {
+    expect(() =>
+      withAndroidStringsDependency(config, {
+        android: {
+          CodePushDeploymentKey: "",
+          CodePushServerURL: "https://updates.example.com",
+        },
+        ios: {
+          CodePushDeploymentKey: "ios-key",
+          CodePushServerURL: "https://updates.example.com",
+        },
+      }),
+    ).toThrow(/CodePushDeploymentKey/);
+  });
+});

--- a/src/android/strings-dependency.ts
+++ b/src/android/strings-dependency.ts
@@ -26,26 +26,24 @@ export const withAndroidStringsDependency: ConfigPlugin<PluginConfigType> = (
   config,
   props,
 ) => {
-  // if (!props?.android?.CodePushServerURL) {
-  //   throw new Error(
-  //       "You need to provide the `CodePushServerURL` Android property for the @config-plugins/react-native-code-push plugin to work."
-  //   );
-  // }
+  if (!props?.android?.CodePushServerURL) {
+    throw new Error(
+      "You need to provide the `CodePushServerURL` Android property for react-native-code-push-plugin to work. App Center is retired, so the default server no longer works.",
+    );
+  }
 
   if (!props?.android?.CodePushDeploymentKey) {
     throw new Error(
-      "You need to provide the `CodePushDeploymentKey` Android property for the @config-plugins/react-native-code-push plugin to work.",
+      "You need to provide the `CodePushDeploymentKey` Android property for react-native-code-push-plugin to work.",
     );
   }
 
   return withStringsXml(config, (xmlProps) => {
-    if (props?.android?.CodePushServerURL) {
-      xmlProps.modResults = setStrings(
-        xmlProps.modResults,
-        "CodePushServerURL",
-        props?.android?.CodePushServerURL,
-      );
-    }
+    xmlProps.modResults = setStrings(
+      xmlProps.modResults,
+      "CodePushServerURL",
+      props.android.CodePushServerURL,
+    );
 
     xmlProps.modResults = setStrings(
       xmlProps.modResults,

--- a/src/ios/__tests__/config.test.ts
+++ b/src/ios/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import type { ExpoConfig } from "expo/config";
+
+import { withIosInfoPlistDependency } from "../info-plist-dependency";
+
+const config = { name: "test", slug: "test" } as ExpoConfig;
+
+describe("iOS config", () => {
+  it.each([undefined, ""])(
+    "rejects a missing CodePush server URL",
+    (CodePushServerURL) => {
+      expect(() =>
+        withIosInfoPlistDependency(config, {
+          android: {
+            CodePushDeploymentKey: "android-key",
+            CodePushServerURL: "https://updates.example.com",
+          },
+          ios: {
+            CodePushDeploymentKey: "ios-key",
+            CodePushServerURL: CodePushServerURL as string,
+          },
+        }),
+      ).toThrow(/App Center is retired/);
+    },
+  );
+
+  it("rejects a missing deployment key", () => {
+    expect(() =>
+      withIosInfoPlistDependency(config, {
+        android: {
+          CodePushDeploymentKey: "android-key",
+          CodePushServerURL: "https://updates.example.com",
+        },
+        ios: {
+          CodePushDeploymentKey: "",
+          CodePushServerURL: "https://updates.example.com",
+        },
+      }),
+    ).toThrow(/CodePushDeploymentKey/);
+  });
+});

--- a/src/ios/info-plist-dependency.ts
+++ b/src/ios/info-plist-dependency.ts
@@ -11,23 +11,20 @@ export const withIosInfoPlistDependency: ConfigPlugin<PluginConfigType> = (
   config,
   props,
 ) => {
-  // if (!props?.ios?.CodePushServerURL) {
-  //   throw new Error(
-  //       "You need to provide the `CodePushServerURL` IOS property for the @config-plugins/react-native-code-push plugin to work."
-  //   );
-  // }
+  if (!props?.ios?.CodePushServerURL) {
+    throw new Error(
+      "You need to provide the `CodePushServerURL` iOS property for react-native-code-push-plugin to work. App Center is retired, so the default server no longer works.",
+    );
+  }
 
   if (!props?.ios?.CodePushDeploymentKey) {
     throw new Error(
-      "You need to provide the `CodePushDeploymentKey` IOS property for the @config-plugins/react-native-code-push plugin to work.",
+      "You need to provide the `CodePushDeploymentKey` iOS property for react-native-code-push-plugin to work.",
     );
   }
 
   return withInfoPlist(config, (infoPlistProps) => {
-    if (props?.ios?.CodePushServerURL) {
-      infoPlistProps.modResults.CodePushServerURL =
-        props?.ios?.CodePushServerURL;
-    }
+    infoPlistProps.modResults.CodePushServerURL = props.ios.CodePushServerURL;
 
     infoPlistProps.modResults.CodePushDeploymentKey =
       props.ios.CodePushDeploymentKey;

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -3,11 +3,11 @@
  */
 export type PluginConfigType = {
   ios: {
-    CodePushServerURL?: string;
+    CodePushServerURL: string;
     CodePushDeploymentKey: string;
   };
   android: {
-    CodePushServerURL?: string;
+    CodePushServerURL: string;
     CodePushDeploymentKey: string;
     CodePushPublicKey?: string;
   };


### PR DESCRIPTION
fix!: require a working CodePush server URL

## Summary

Prebuild now requires a self-hosted CodePush server URL for Android and iOS, and stops with an actionable error before it can write config for App Center's retired endpoint.

## Details

- Makes the server URL required in the plugin config type and at runtime.
- Writes the validated URL into both native projects every time.
- This is a breaking change for apps still relying on the retired App Center default. They need to point both platforms at a self-hosted server before prebuild will run.
- Covers missing and empty URLs on Android and iOS.

## Testing steps

1. From the repository root, run:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run test
   ```

2. Confirm every command exits successfully. The test output should show Android and iOS rejecting both missing and empty update server addresses.
